### PR TITLE
Remove overridden color CSS property

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,6 @@
     }
 
     .container p a {
-        color: inherit;
         text-decoration: none;
         color: pink;
     }


### PR DESCRIPTION
The color of `.container p a` will be `pink`. No need to define the previous `color: inherit`.