### PR TITLE
Use HTTPS for Figma URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
     <footer>
         <span>
             Designed in
-            <a href="http://figma.com">Figma</a>.</span>
+            <a href="https://figma.com">Figma</a>.</span>
         <span>Built in
             <a href="https://code.visualstudio.com">Code</a>.</span>
         <span>Open source on


### PR DESCRIPTION
Figma's website is served over HTTPS but the link being used specifies HTTP. No reason for a redirect to be required.