### PR TITLE
prevent scrollbar from flickering

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -29,9 +29,6 @@ body {
     color: #BBB;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    opacity: 0;
-    transform: translateY(var(--move-in-offset));
-    animation: 1500ms 500ms forwards move-in;
 }
 
 ::-moz-selection {
@@ -58,6 +55,10 @@ a:hover {
     max-width: 32rem;
     margin: 0 auto;
     flex: 1;
+    
+  opacity: 0;
+  transform: translateY(var(--move-in-offset));
+  animation: 1500ms 500ms forwards move-in;
 }
 
 .logo-link {


### PR DESCRIPTION
animating a container and not the document body prevents that scrollbar flickering when the animation ends.