### PR TITLE
Style the header section, add ARIA Landmarks

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,94 +1,114 @@
 :root {
-    --blue: #05A6F0;
-    --move-in-offset: 1rem;
+  --blue: #05A6F0;
+  --move-in-offset: 1rem;
 }
-
 @keyframes move-in {
-    from {
-        transform: translateY(var(--move-in-offset));
-        opacity: 0;
-    }
-    to {
-        transform: none;
-        opacity: 1;
-    }
+  from {
+    transform: translateY(var(--move-in-offset));
+    opacity: 0;
+  }
+
+  to {
+    transform: none;
+    opacity: 1;
+  }
 }
 
 html {
-    font-size: 125%;
-    font-family: Inconsolata, Consolas, monospace;
-    line-height: 1.25;
-    background-color: #080808;
+  font-size: 125%;
+  font-family: Inconsolata, Consolas, monospace;
+  line-height: 1.25;
+  background-color: #080808;
 }
 
 body {
-    display: flex;
-    flex-flow: column nowrap;
-    min-height: 100vh;
-    margin: 0;
-    color: #BBB;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    opacity: 0;
-    transform: translateY(var(--move-in-offset));
-    animation: 1500ms 500ms forwards move-in;
+  display: flex;
+  flex-flow: column nowrap;
+  min-height: 100vh;
+  margin: 0;
+  color: #BBBBBB;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  opacity: 0;
+  transform: translateY(var(--move-in-offset));
+  animation: 1500ms 500ms forwards move-in;
+  overflow: hidden;
+}
+
+header {
+  background: white;
+  color: black;
+  padding: 2rem 0;
+  margin-bottom: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header__text {
+  text-transform: uppercase;
+  font-weight: bold;
+  margin: 1rem 2rem;
+}
+
+main {
+  max-width: 32rem;
+  margin: 0 auto;
+  flex: 1;
+  padding: 0 1rem;
 }
 
 ::-moz-selection {
-    color: white;
-    background-color: var(--blue);
+  color: white;
+  background-color: var(--blue);
 }
 
 ::selection {
-    color: white;
-    background-color: var(--blue);
+  color: white;
+  background-color: var(--blue);
 }
 
 a {
-    color: white;
-    text-decoration: none;
-    transition: 150ms color;
+  color: white;
+  text-decoration: none;
+  transition: 150ms color;
 }
 
 a:hover {
-    color: var(--blue);
-}
-
-.container {
-    max-width: 32rem;
-    margin: 0 auto;
-    flex: 1;
+  color: var(--blue);
 }
 
 .logo-link {
-    display: block;
-    width: 4rem;
-    height: 4rem;
-    margin: 2.5rem auto;
+  display: block;
+  width: 4rem;
+  height: 4rem;
 }
 
 .logo-image {
-    display: block;
-    width: 100%;
-    height: auto;
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 .footer {
-    font-size: 80%;
+  font-size: 80%;
+  text-align: center;
+  padding: 1rem 0;
+}
+@media only screen and (max-width: 40em) {
+  header {
+    flex-direction: column;
     text-align: center;
     padding: 1rem 0;
-}
+    margin-bottom: 1rem;
+  }
 
-@media only screen and (max-width: 40em) {
-    .container {
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
-    .footer {
-        text-align: unset;
-        padding: 1rem;
-    }
-    .footer-piece {
-        display: block;
-    }
+  .footer {
+    text-align: unset;
+    padding: 1rem;
+  }
+
+  .footer-piece {
+    display: block;
+  }
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -2,14 +2,12 @@
   --blue: #05A6F0;
   --move-in-offset: 1rem;
 }
-@keyframes move-in {
+@keyframes fade-in {
   from {
-    transform: translateY(var(--move-in-offset));
     opacity: 0;
   }
 
   to {
-    transform: none;
     opacity: 1;
   }
 }
@@ -22,6 +20,16 @@ html {
 }
 
 body {
+  opacity: 1;
+  transition: 1s opacity;
+}
+
+body.fade-out {
+  opacity: 0;
+  transition: none;
+}
+
+body {
   display: flex;
   flex-flow: column nowrap;
   min-height: 100vh;
@@ -30,8 +38,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   opacity: 0;
-  transform: translateY(var(--move-in-offset));
-  animation: 1500ms 500ms forwards move-in;
+  animation: 1500ms 500ms forwards fade-in;
   overflow: hidden;
 }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -20,16 +20,6 @@ html {
 }
 
 body {
-  opacity: 1;
-  transition: 1s opacity;
-}
-
-body.fade-out {
-  opacity: 0;
-  transition: none;
-}
-
-body {
   display: flex;
   flex-flow: column nowrap;
   min-height: 100vh;
@@ -38,8 +28,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   opacity: 0;
-  animation: 1500ms 500ms forwards fade-in;
-  overflow: hidden;
+  animation: 1500ms 400ms forwards fade-in;
 }
 
 header {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -28,7 +28,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   opacity: 0;
-  animation: 1500ms 400ms forwards fade-in;
+  animation: 1500ms 200ms forwards fade-in;
 }
 
 header {

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 
 <body>
     <div class="container">
-        <header>
+        <header role="banner">
             <a class="logo-link" href="https://microsoft.com">
                 <img class="logo-image" src="msft-square.svg" alt="Microsoft logo" width="80" height="80" />
             </a>
@@ -22,7 +22,7 @@
                 on the planet.
             </p>
         </header>
-        <main>
+        <main role="main">
             <p>We have open positions for technical product designers &amp; design leaders in San Francisco, Seattle, and elsewhere.
             </p>
 
@@ -38,7 +38,7 @@
                 <a href="mailto:dasiege@microsoft.com">email us</a>.</p>
         </main>
     </div>
-    <footer class="footer">
+    <footer class="footer" role="contentinfo">
         <span class="footer-piece">
             Designed in
             <a href="https://figma.com">Figma</a>.</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,31 +13,31 @@
 
 
 <body>
-    <div class="container">
-        <header role="banner">
-            <a class="logo-link" href="https://microsoft.com">
-                <img class="logo-image" src="msft-square.svg" alt="Microsoft logo" width="80" height="80" />
-            </a>
-            <p>Microsoft is looking for designers who code to help create the most compelling developer tools &amp; services
-                on the planet.
-            </p>
-        </header>
-        <main role="main">
-            <p>We have open positions for technical product designers &amp; design leaders in San Francisco, Seattle, and elsewhere.
-            </p>
+    <header role="banner">
+        <a class="logo-link" href="https://microsoft.com">
+            <img class="logo-image" src="msft-square.svg" alt="Microsoft logo" width="80" height="80" />
+        </a>
+        <p class="header__text">Microsoft is looking for designers who code
+            <br> to help create the most compelling developer tools
+            <br> &amp; services on the planet
+        </p>
+    </header>
+    <main role="main">
+        <p>We have open positions for technical product designers &amp; design leaders in San Francisco, Seattle, and elsewhere.
+        </p>
 
-            <p>We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build
-                the future of software development.</p>
+        <p>We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build
+            the future of software development.</p>
 
-            <p>We believe in diversity, openness, and building delightful tools that empower every person and organization to
-                achieve more.
-            </p>
+        <p>We believe in diversity, openness, and building delightful tools that empower every person and organization to achieve
+            more.
+        </p>
 
-            <p>Interested? Send a PR with any improvement to
-                <a href="https://github.com/Microsoft/join-dev-design">microsoft/join-dev-design</a> or
-                <a href="mailto:dasiege@microsoft.com">email us</a>.</p>
-        </main>
-    </div>
+        <p>Interested? Send a PR with any improvement to
+            <a href="https://github.com/Microsoft/join-dev-design">microsoft/join-dev-design</a> or
+            <a href="mailto:dasiege@microsoft.com">email us</a>.</p>
+    </main>
+
     <footer class="footer" role="contentinfo">
         <span class="footer-piece">
             Designed in


### PR DESCRIPTION
I wanted to make the Header section more apparent and separate from the page content

![localhost_5000_ fhd](https://user-images.githubusercontent.com/6593585/42967021-9d2133dc-8ba7-11e8-855e-9aa68298c15e.png)


Also removed the container div as it became unnecessary after I made the header full width
Added ARIA Landmark roles for a11y
Changed the animation from move-in to fade-in (although I am partial to no animation in this case)
Added media queries to support the changes