### PR TITLE
Fix vertical scrollbar appearing below 1000px

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -44,7 +44,7 @@ html {
 body {
   display: flex;
   flex-flow: column nowrap;
-  min-height: 99vh;
+  min-height: calc(100vh - 10px);
   margin: 5px;
   color: #BBB;
   background-color: rgba(18, 18, 18, 1);


### PR DESCRIPTION
I’m not interested in the programme, but the scrollbar offended my sensibilities.

99vh is *always* the wrong thing. Literally *always*, I think. (If you can come up with a geunine case for it, I’d love to hear it!) For that matter, the vw and vh units are broken in the presence of scrollbars anyway…