### PR TITLE
Increase contrast of GitHub link when in hover state for accessibility

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -160,7 +160,7 @@ footer [href*="code"]:hover {
 }
 
 footer [href*="github"]:hover {
-  color: #2B3137;
+  color: #6cc644;
 }
 
 @media only screen and (max-width: 40em) {


### PR DESCRIPTION
Not looking for the job as I already work there, but wanted to join in on the fun.  Excited for Microsoft to build whatever it is they're building.

Noticed when hovering the GitHub link in the footer it become almost unreadable with grey (`#2B3137`) on top of grey (`rgba(18, 18, 18, 1)`).  I think there are accessibility guidelines for minimum contrast and tried to fix it.

I'm not sure if these are official, but I found some GitHub brand colors here:
https://brandcolors.net/b/github

Since purple (figma) and blue (Code) were already used, chose green.

Example of the change:
Neutral:
![image](https://user-images.githubusercontent.com/2856501/42981579-a69cabc8-8b91-11e8-9c40-33455c80f313.png)

Before:
![image](https://user-images.githubusercontent.com/2856501/42981570-978caf34-8b91-11e8-87bd-eff07fa4f623.png)

After: (Notice the Green)
![image](https://user-images.githubusercontent.com/2856501/42981589-ba237c12-8b91-11e8-9fc2-cc3a002ca53c.png)
