### PR TITLE
Add link to GitHub contributors

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
             <a href="https://code.visualstudio.com" title="Visual Studio Code is a code editor redefined and optimized for building and debugging modern web and cloud applications.">Code</a>.</span>
         <span class="footer-piece">
             Created by
-            <span id="contributors">10</span> contributors on
+            <a href="https://github.com/Microsoft/join-dev-design/graphs/contributors" id="contributors" title="Contributors to the GitHub repository join-dev-design by the Microsoft organization">10</a> contributors on
             <a href="https://github.com/Microsoft/join-dev-design" title="GitHub repository join-dev-design by the Microsoft organization">GitHub</a>.</span>
     </footer>
 </body>


### PR DESCRIPTION
A small change which adds link to the contributors page on GH.