### PR TITLE
add links to the microsoft career pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,10 @@
             <hr>
         </header>
         <main>
-            <p>We have open positions for technical product designers &amp; design leaders in San Francisco, Seattle, and elsewhere.
+            <p>We have open positions for technical product designers &amp; design leaders in
+                <a href="https://careers.microsoft.com/us/en/l-bayarea">San Francisco</a>,
+                <a href="https://careers.microsoft.com/us/en/l-seattlearea">Seattle</a>, and
+                <a href="https://careers.microsoft.com/us/en/locations">elsewhere</a>.
             </p>
 
             <p>We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build


### PR DESCRIPTION
Would it make sense to add links to the MS Career page or is it too obvious?
If yes, a more subtle styling for those links could keep the texts readability :thinking: 