### PR TITLE
footer: change role from 'footer' to 'contentinfo' as 'footer' is an invalid value

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
                 <a href="mailto:dasiege@microsoft.com" title="Email address for dasiege@microsoft.com">email us</a>.</p>
         </main>
     </div>
-    <footer class="footer" role="footer">
+    <footer class="footer" role="contentinfo">
         <span class="footer-piece">Built in
             <a href="https://code.visualstudio.com" title="Visual Studio Code is a code editor redefined and optimized for building and debugging modern web and cloud applications.">Code</a>.</span>
         <span class="footer-piece">


### PR DESCRIPTION
This PR changes the `footer role="footer"` to `footer role="contentinfo"` as the `"footer" value is invalid. This increases the accessibility of the page, and bumps up the Chrome a11y audit score from 94 to 100. 

For more information on `contentinfo` : https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html