### PR TITLE
content: add links to microsoft sites for diversity and openess resources

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
             <p>We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build
                 the future of software development.</p>
 
-            <p>We believe in diversity, openness, and building delightful tools that empower every person and organization to
+            <p>We believe in <a href="https://www.microsoft.com/en-us/diversity/" title="Microsoft's diversity and inclusion efforts">diversity</a>, <a href="https://open.microsoft.com/" title="Articles and updates on Microsoft's open source contributions">openness</a>, and building delightful tools that empower every person and organization to
                 achieve more.
             </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
             <p>We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build
                 the future of software development.</p>
 
-            <p>We believe in <a href="https://www.microsoft.com/en-us/diversity/" title="Microsoft's diversity and inclusion efforts">diversity</a>, <a href="https://open.microsoft.com/" title="Articles and updates on Microsoft's open source contributions">openness</a>, and building delightful tools that empower every person and organization to
+            <p>We believe in <a href="https://www.microsoft.com/en-us/diversity/" title="Microsoft's diversity and inclusion efforts">diversity</a>, <a href="https://open.microsoft.com/" title="Articles and updates on Microsoft's open source contributions">openness</a>, and building <a href="https://www.microsoft.com/design/" title="Microsoft's design tools and Fluent Design System">delightful tools</a> that empower every person and organization to
                 achieve more.
             </p>
 


### PR DESCRIPTION
Link the `diversity` and `openness` words to two public facing Microsoft sites, that explain a bit more about the companies standpoints on those two areas. 

Linked sites:
https://www.microsoft.com/en-us/diversity/
https://open.microsoft.com/

Tested the paragraph with VoiceOver, and this update doesn't seem to interfere with audio transcription. 

I couldn't find a MS site that had a list of the 'delightful tools' being built. 

Screenshot: 
![image](https://user-images.githubusercontent.com/607813/43021274-17d53a7c-8c31-11e8-9ee6-1cf800fc2f12.png)
