### PR TITLE
Prettier code formatting added... need more tooling?

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "editor.formatOnSave": true
+  "editor.formatOnSave": true
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -85,7 +85,6 @@ html {
     #ffba08 67%
   );
 }
-
 html:before {
   content: "";
   position: absolute;
@@ -110,7 +109,6 @@ html:before {
   );
   animation: 4s both root-gradient linear infinite;
 }
-
 body {
   display: flex;
   flex-flow: column nowrap;
@@ -123,27 +121,22 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-size: 16px;
 }
-
 ::-moz-selection {
   color: white;
   background-color: var(--blue);
 }
-
 ::selection {
   color: white;
   background-color: var(--blue);
 }
-
 a {
   color: var(--link-color);
   text-decoration: none;
   transition: 150ms color;
 }
-
 a:hover {
   color: var(--blue);
 }
-
 .container {
   max-width: 40rem;
   margin: 0 auto;
@@ -152,30 +145,25 @@ a:hover {
   max-width: 40rem;
   width: 40rem;
 }
-
 p,
 h1 {
   margin: 0;
   padding: 10px 0.5em;
 }
-
 p {
   font-size: 1.125rem;
 }
-
 @media only screen and (min-width: 40em) {
   p {
     font-size: 1.25rem;
   }
 }
-
 header h1 {
   animation: var(--move-in-animation);
   animation-delay: calc(var(--move-in-base-delay) * 4);
   font-size: 1.688rem;
   font-weight: bolder;
 }
-
 header hr {
   border: 0;
   height: 0;
@@ -185,12 +173,10 @@ header hr {
   animation: var(--move-in-animation);
   animation-delay: 250ms;
 }
-
 main p {
   animation: var(--move-in-animation);
   animation-delay: calc(var(--move-in-base-delay) * 5);
 }
-
 main p:nth-child(2) {
   animation-delay: calc(var(--move-in-base-delay) * 6);
 }
@@ -200,24 +186,20 @@ main p:nth-child(3) {
 main p:nth-child(4) {
   animation-delay: calc(var(--move-in-base-delay) * 8);
 }
-
 .logo-link {
   display: block;
   width: 5rem;
   height: 5rem;
   margin: 2.5rem auto;
 }
-
 .logo-link:hover {
   animation: 1s both logo-tiles-hover linear infinite;
 }
-
 .logo-image {
   display: block;
   width: 100%;
   height: auto;
 }
-
 .logo-css {
   display: flex;
   flex-wrap: wrap;
@@ -225,7 +207,6 @@ main p:nth-child(4) {
   width: 100%;
   margin: 0;
 }
-
 .logo-tile {
   display: block;
   width: 45%;
@@ -241,6 +222,7 @@ main p:nth-child(4) {
   background-color: #81bc06;
   animation-delay: var(--logo-tiles-in-delay);
 }
+
 .logo-tile--blue {
   background-color: #05a6f0;
   animation-delay: calc(var(--logo-tiles-in-delay) * 2);
@@ -249,35 +231,29 @@ main p:nth-child(4) {
   background-color: #ffba08;
   animation-delay: calc(var(--logo-tiles-in-delay) * 3);
 }
-
 .footer {
   text-align: center;
   padding: 1.25rem 0;
   animation: var(--move-in-animation);
   animation-delay: calc(var(--move-in-base-delay) * 9);
 }
-
 footer [href*="code"]:hover {
   color: #007acc;
 }
-
 footer [href*="github"]:hover {
   color: #6cc644;
 }
-
 @media only screen and (max-width: 40em) {
   .container {
     max-width: calc(100vw - 10vw);
     margin: 0 auto;
   }
-
   footer {
     text-align: unset;
     padding: 1.25rem 0 2.5rem;
     max-width: calc(100vw - 10vw);
     margin: 0 auto;
   }
-
   .footer-piece {
     display: block;
   }

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -16,7 +16,7 @@
   font-size: 0;
   text-align: center;
   z-index: 900;
-  transition: opacity .3s ease;
+  transition: opacity 0.3s ease;
 }
 
 .theme__list,
@@ -38,9 +38,9 @@
   display: inline-block;
 }
 
-.theme__item+.theme__item {
+.theme__item + .theme__item {
   margin-left: 0.5rem;
-  transition: margin-left .3s ease;
+  transition: margin-left 0.3s ease;
 }
 
 .theme__button {
@@ -54,11 +54,11 @@
   border-radius: 0.6rem;
 }
 
-.theme__button[value='dark'] {
+.theme__button[value="dark"] {
   background: black;
 }
 
-.theme__button[value='light'] {
+.theme__button[value="light"] {
   background: white;
 }
 
@@ -72,15 +72,15 @@
 
 @media only screen and (min-width: 640px) {
   .theme {
-    opacity: .5;
+    opacity: 0.5;
   }
   .theme:hover {
     opacity: 1;
   }
-  .theme__item+.theme__item {
+  .theme__item + .theme__item {
     margin-left: -0.8rem;
   }
-  .theme:hover .theme__item+.theme__item {
+  .theme:hover .theme__item + .theme__item {
     margin-left: 0.5rem;
   }
 }
@@ -88,7 +88,7 @@
 /* Theme Setting */
 
 body {
-  transition: background-color .3s ease;
+  transition: background-color 0.3s ease;
 }
 
 body.js-theme-light {
@@ -106,7 +106,7 @@ body.js-theme-light {
 
 body.js-theme-code {
   color: lightslategrey;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: "Courier New", Courier, monospace;
 }
 
 .js-theme-light .theme__button {

--- a/docs/theme/theme.js
+++ b/docs/theme/theme.js
@@ -1,20 +1,20 @@
 var $body = document.body;
-var $themeBtns = document.querySelectorAll('.js-theme-button');
+var $themeBtns = document.querySelectorAll(".js-theme-button");
 
-$themeBtns[0].setAttribute('disabled', true);
+$themeBtns[0].setAttribute("disabled", true);
 
-$themeBtns.forEach(function (ele) {
-  ele.onclick = function (e) {
+$themeBtns.forEach(function(ele) {
+  ele.onclick = function(e) {
     var selectedName = e.target.value;
 
-    $themeBtns.forEach(function (ele) {
+    $themeBtns.forEach(function(ele) {
       var themeName = ele.value;
       if (themeName === selectedName) return;
-      $body.classList.remove('js-theme-' + themeName);
-      ele.removeAttribute('disabled');
-    })
+      $body.classList.remove("js-theme-" + themeName);
+      ele.removeAttribute("disabled");
+    });
 
-    $body.classList.add('js-theme-' + selectedName);
-    ele.setAttribute('disabled', true);
-  }
+    $body.classList.add("js-theme-" + selectedName);
+    ele.setAttribute("disabled", true);
+  };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,15 @@
         "negotiator": "0.6.1"
       }
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.2"
+      }
+    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -128,6 +137,17 @@
         "repeat-element": "1.1.2"
       }
     },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      }
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -143,6 +163,27 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "ci-info": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
     },
     "colors": {
       "version": "1.3.0",
@@ -182,6 +223,17 @@
       "requires": {
         "object-assign": "4.1.1",
         "vary": "1.1.2"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "debug": {
@@ -229,6 +281,12 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -248,6 +306,21 @@
         "split": "0.3.3",
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
+      }
+    },
+    "execa": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -318,6 +391,15 @@
         "unpipe": "1.0.0"
       }
     },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -345,6 +427,12 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
@@ -368,6 +456,12 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "http-auth": {
@@ -408,6 +502,31 @@
       "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
       "dev": true
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        }
+      }
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -428,6 +547,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.3"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -486,6 +614,12 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
@@ -496,6 +630,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
@@ -535,6 +675,26 @@
         "proxy-middleware": "0.15.0",
         "send": "0.16.2",
         "serve-index": "1.9.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "map-stream": {
@@ -630,6 +790,12 @@
         }
       }
     },
+    "mri": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.1.tgz",
+      "integrity": "sha1-haom09ru7t+A3FmEr5XMXKXK2fE=",
+      "dev": true
+    },
     "ms": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -649,6 +815,15 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
       }
     },
     "object-assign": {
@@ -691,6 +866,36 @@
         "is-wsl": "1.1.0"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.3.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -709,10 +914,22 @@
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "pause-stream": {
@@ -730,6 +947,25 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
+      "dev": true
+    },
+    "pretty-quick": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.6.0.tgz",
+      "integrity": "sha512-bnCmsPy98ERD7VWBO+0y1OGWLfx/DPUjNFN2ZRVyxuGBiic1BXAGgjHsTKgBIbPISdqpP6KBEmRV0Lir4xu/BA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "execa": "0.8.0",
+        "find-up": "2.1.0",
+        "ignore": "3.3.10",
+        "mri": "1.1.1"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -740,6 +976,12 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
       "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "randomatic": {
@@ -921,6 +1163,27 @@
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
     "split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
@@ -952,6 +1215,27 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
       }
     },
     "through": {
@@ -1010,6 +1294,21 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "start": "live-server docs"
+    "start": "live-server docs",
+    "precommit": "pretty-quick --staged",
+    "prettier": "prettier"
   },
   "repository": {
     "type": "git",
@@ -20,6 +22,9 @@
   },
   "homepage": "https://github.com/Microsoft/join-dev-design#readme",
   "devDependencies": {
-    "live-server": "^1.2.0"
+    "husky": "^0.14.3",
+    "live-server": "^1.2.0",
+    "prettier": "^1.13.7",
+    "pretty-quick": "^1.6.0"
   }
 }


### PR DESCRIPTION
## What's added?

- Prettier and pre-commit hooks for code styling
- Styled existing JS and CSS files

## What about other tooling?

Well, if this repo is to kept simple, more tooling can't be added because that would make it more complex to make changes. However, since many are involved, we will lose consistency without much tooling. Adding Prettier was an opinionated choice from my side and I don't know if this will get merged. If it does, do we go for more? Currently, HTML files are not being fixed (Prettier can't handle them) and if we care about optimizing, then we could be going for webpack or some other solution.

I wanted to raise this as an issue but it seems there is no option for doing that. @dvdsgl  is it cool to reorganize to support tooling or should this be kept simple?