### PR TITLE
Corrected theme item off-by-1 pixel error

### DIFF
--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -36,6 +36,7 @@
 .theme__item {
   position: relative;
   display: inline-block;
+  vertical-align: top;
 }
 
 .theme__item + .theme__item {


### PR DESCRIPTION
Changing this:

![chrome_2018-07-21_14-03-07](https://user-images.githubusercontent.com/22254235/43032712-217829e4-8cf0-11e8-96cf-8f50a79348f9.png)

into this:

![chrome_2018-07-21_14-04-29](https://user-images.githubusercontent.com/22254235/43032713-25b765e2-8cf0-11e8-914d-386a80e8f5f5.png)
