### PR TITLE
Fix FOUC issue with root gradient

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -72,6 +72,9 @@ html {
   font-size: 16px;
   font-family: Inconsolata, Consolas, monospace;
   line-height: 1.25;
+  background-color: rgba(18, 18, 18, 1);
+}
+html[data-loaded] {
   background-image: -webkit-gradient(
     linear,
     left bottom,
@@ -93,7 +96,6 @@ html:before {
   left: 0;
   height: 100%;
   width: 100%;
-  opacity: 0;
   z-index: -1;
   background-image: -webkit-gradient(
     linear,
@@ -107,7 +109,7 @@ html:before {
     #ffbb00 33%,
     #00a1f1 67%
   );
-  animation: 4s both root-gradient linear infinite;
+  animation: 4s both root-gradient ease-in-out infinite;
 }
 body {
   display: flex;

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,5 +117,14 @@
         console.log('Fetch Error :-S', err)
       })
   </script>
+  <script type="text/javascript">
+    function markDocumentAsLoaded() {
+      setTimeout(function() {
+        document.documentElement.dataset.loaded = true
+      }, 1000)
+    }
+
+    addEventListener('load', markDocumentAsLoaded);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This quick fix prevents a rare FUOC that results in:

![2018-07-21_16-05-38](https://user-images.githubusercontent.com/22254235/43035399-543d501c-8d21-11e8-99ce-21a23ed3ddef.gif)

by delaying the yellow to blue root gradient from displaying until the content loads and can cover all but the border, as intended.