### PR TITLE
Add height to fix html background via body

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -17,29 +17,62 @@
 }
 
 @keyframes move-in {
-  from { transform: translateY(var(--move-in-offset)); opacity: 0; }
-  to   { transform: translateY(0); opacity: 1; }
+  from {
+    transform: translateY(var(--move-in-offset));
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 @keyframes logo-tiles-in {
-  0%   { opacity: 0; filter: grayscale(1) hue-rotate(100deg); }
-  25%  { opacity: 1; }
-  50%  { opacity: 1; }
-  55%  { opacity: 0; }
-  60%  { opacity: 1; filter: grayscale(1) hue-rotate(100deg); }
-  100% { opacity: 1; filter: grayscale(0) hue-rotate(0deg); }
+  0% {
+    opacity: 0;
+    filter: grayscale(1) hue-rotate(100deg);
+  }
+  25% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 1;
+  }
+  55% {
+    opacity: 0;
+  }
+  60% {
+    opacity: 1;
+    filter: grayscale(1) hue-rotate(100deg);
+  }
+  100% {
+    opacity: 1;
+    filter: grayscale(0) hue-rotate(0deg);
+  }
 }
 
 @keyframes logo-tiles-hover {
-  from { filter: hue-rotate(0deg); }
-  to   { filter: hue-rotate(360deg); }
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
+  }
 }
 
 @keyframes root-gradient {
-  0%   { opacity: 0; }
-  40%  { opacity: 1; }
-  60%  { opacity: 1; }
-  100% { opacity: 0; }
+  0% {
+    opacity: 0;
+  }
+  40% {
+    opacity: 1;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 /* Common */
@@ -47,7 +80,8 @@
 html {
   position: relative;
   font-size: 125%;
-  font-family: Inconsolata, Consolas, "SFMono-Regular", Menlo, "DejaVu Sans Mono", monospace;
+  font-family: Inconsolata, Consolas, "SFMono-Regular", Menlo,
+    "DejaVu Sans Mono", monospace;
   line-height: 1.25;
   background: linear-gradient(to bottom, var(--blue) 33%, var(--yellow) 67%);
   background-color: var(--page-background);
@@ -71,6 +105,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: calc(100vh - 10px);
   min-height: calc(100vh - 10px);
   margin: 5px;
   color: var(--page-color);
@@ -187,11 +222,21 @@ main h1 {
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
-main p { animation: var(--move-in-animation); }
-main p:nth-of-type(1) { animation-delay: calc(var(--move-in-base-delay) * 5); }
-main p:nth-of-type(2) { animation-delay: calc(var(--move-in-base-delay) * 6); }
-main p:nth-of-type(3) { animation-delay: calc(var(--move-in-base-delay) * 7); }
-main p:nth-of-type(4) { animation-delay: calc(var(--move-in-base-delay) * 8); }
+main p {
+  animation: var(--move-in-animation);
+}
+main p:nth-of-type(1) {
+  animation-delay: calc(var(--move-in-base-delay) * 5);
+}
+main p:nth-of-type(2) {
+  animation-delay: calc(var(--move-in-base-delay) * 6);
+}
+main p:nth-of-type(3) {
+  animation-delay: calc(var(--move-in-base-delay) * 7);
+}
+main p:nth-of-type(4) {
+  animation-delay: calc(var(--move-in-base-delay) * 8);
+}
 
 /* Footer */
 


### PR DESCRIPTION
This PR adds the `height` property to the `body` selector to fix the layout of the rainbow background border. 

😉 look at the bottom of the before/after images below.

# before
![join microsoft developer design](https://user-images.githubusercontent.com/24152/43039804-9689f386-8ce9-11e8-9c57-c192f28ecf16.jpg)

# after
![join microsoft developer design 1](https://user-images.githubusercontent.com/24152/43039805-9948f66c-8ce9-11e8-9fb1-92d6bb4717a1.jpg)

