### PR TITLE
FIX: Add meta description for 100% on Lighthouse SEO audit

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Join Microsoft Developer Design</title>
+  <meta name="description" content="Microsoft is hiring technical product designers and design leaders.">
   <meta property="og:title" content="Join Microsoft Developer Design">
   <meta property="og:site_name" content="https://microsoft.github.io/join-dev-design/">
   <meta property="og:url" content="https://microsoft.github.io/join-dev-design/">


### PR DESCRIPTION
Let's get 100% on the Google Lighthouse site audit SEO score!

![screenshot 2018-07-21 15 03 02](https://user-images.githubusercontent.com/24152/43040386-37a429a0-8cf7-11e8-9192-53c0cefc41b0.png)

Validation: https://stackoverflow.com/questions/22350105/whats-the-difference-between-meta-name-and-meta-property