### PR TITLE
Theme selector improved

### DIFF
--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -69,6 +69,7 @@
 
 .theme__button:not([disabled]) {
   cursor: pointer;
+  z-index: 100;
 }
 
 @media only screen and (min-width: 640px) {

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -64,6 +64,7 @@
 }
 
 .theme__button:disabled {
+  z-index: 95;
   border: 3px solid #444;
 }
 


### PR DESCRIPTION
This commit alternates the layering of the balls depending on the state of the current theme.
During the dark theme, the white ball comes on top.
During the white theme, the dark ball comes on top.
This makes the theme selector feel more alive.
By placing the alternate color on top, it makes it clearer to the user that the theme can be changed.

![circles](https://user-images.githubusercontent.com/5862751/43044503-fbe88c62-8de1-11e8-9cb8-86776ea77c55.png)
