### PR TITLE
Log logo on console using text-shadow

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,27 +93,10 @@
   </footer>
   <script async src="theme/theme.js"></script>
   <script>
-    function logLogo(sz) {
-      const sp = 10;
-      const styles = [
-        'font-size: 1px',
-        'display: inline-block',
-        'padding-left: ' + (sz * 2 + sp) + 'px',
-        'padding-top: ' + (sz * 2 + sp) + 'px',
-        'background-image: linear-gradient(90deg, #F0521F 0px, #F0521F <p1>px, transparent <p1>px, transparent <p2>px, #7FCC2C <p2>px, #7FCC2C <p3>px, transparent <p3>px), linear-gradient(90deg, #00ADF0 0px, #00ADF0 <p4>px, transparent <p4>px, transparent <p5>px, #FCBA12 <p5>px, #FCBA12 <p6>px, transparent <p6>px)'
-          .replace(/<p1>/g, '' + (sz))
-          .replace(/<p2>/g, '' + (sz + sp))
-          .replace(/<p3>/g, '' + (sz * 2 + sp))
-          .replace(/<p4>/g, '' + (sz))
-          .replace(/<p5>/g, '' + (sz + sp))
-          .replace(/<p6>/g, '' + (sz * 2 + sp)),
-        'background-repeat: no-repeat',
-        'background-size: ' + (sz * 2 + sp) + 'px ' + sz + 'px',
-        'background-position: 0 0, 0 ' + (sz + sp) + 'px'
-      ];
-      
-      console.log('%c ', styles.join(';'));
-      console.log('👋 Hi there! 👋\n\nIt seems you like to poke around as much as we do.\n\nhttps://github.com/Microsoft/join-dev-design')
+    function logLogo(size) {
+      const style = `font-family: Arial; font-size: ${size}px; line-height: 2em; color: #f33525; text-shadow: 0.5em 0 0 #81bc06, 0 0.5em 0 #05a6f0, 0.5em 0.5em 0 #ffba08;`;
+      console.log('%c■     ', style);
+      console.log('👋 Hi there! 👋\n\nIt seems you like to poke around as much as we do.\n\nhttps://github.com/Microsoft/join-dev-design');
     }
     
     logLogo(100);


### PR DESCRIPTION
The logo was broken in Safari ([discussion](
https://github.com/Microsoft/join-dev-design/pull/79#issuecomment-406859359)).
This PR made a different implementation by using `text-shadow` instead of gradients that fixes this issue.
Tested on all modern browsers (Edge/Chrome/Firefox/Safari) on both Windows & macOS, results works like expected:
![img_1018](https://user-images.githubusercontent.com/1941540/43046283-2521da0e-8df9-11e8-8a59-d999bd5a1df4.JPG)

