### PR TITLE
[A11y] [High Contrast] Added transparent outline to the logo

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -154,6 +154,7 @@ h1 {
   width: 45%;
   height: 45%;
   margin: 2.5%;
+  outline : 1px solid transparent;
   animation: var(--logo-tiles-in-animation);
 }
 


### PR DESCRIPTION
For people who use a high contrast theme.

Before
![before](https://user-images.githubusercontent.com/2761516/43047559-8b58d8f2-8df6-11e8-9513-ae882431859a.png)


After
![after](https://user-images.githubusercontent.com/2761516/43047562-9826800c-8df6-11e8-9dcd-815ae338b682.png)
