### PR TITLE
Added copy to clipboard function

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -349,3 +349,63 @@ footer [href*="github"]:focus {
 .time-travel a {
   cursor: pointer;
 }
+
+/* COPY TO CLIPBOARD */
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  font-size: var(--small-font-size);
+  visibility: hidden;
+  width: 140px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  bottom: 110%;
+  left: 50%;
+  margin-left: -75px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+
+.tooltip > button {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: var(--base-font-size);
+  font-family: var(--primary-typeface);
+  line-height: var(--base-font-line-height);
+  color: var(--brand-yellow);
+  text-decoration: none;
+  transition: 400ms color;
+}
+
+.tooltip > button:focus {
+  outline: 0;
+}
+
+input#emailInput {
+  display: none;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,15 +33,13 @@
     </header>
     <main>
       <h1>
-        Microsoft is looking for designers who code to help create the most compelling developer tools&nbsp;&amp;&nbsp;services on
-        the planet.
+        Microsoft is looking for designers who code to help create the most compelling developer tools&nbsp;&amp;&nbsp;services on the planet.
       </h1>
       <p>
         We have open positions for technical product designers &amp; design leaders in San Francisco, Seattle, and elsewhere.
       </p>
       <p>
-        We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build the future
-        of software development.
+        We use PCs, Macs, Figma, Sketch, GitHub, JavaScript, ZEIT, and other modern tools to design, prototype, and build the future of software development.
       </p>
       <p>
         We believe in diversity, openness, and building delightful tools that empower every person and organization to achieve more.
@@ -49,7 +47,13 @@
       <p>
         Interested? Send a PR with any improvement to
         <a href="https://github.com/Microsoft/join-dev-design" title="GitHub repository join-dev-design by the Microsoft organization">microsoft/join-dev-design</a> or
-        <a href="mailto:dasiege@microsoft.com" title="Email address for dasiege@microsoft.com">email us</a>.
+        <span class="tooltip">
+          <input type="email" value="dasiege@microsoft.com" id="emailInput">
+          <button onclick="copyEmail()" onmouseout="outFunc()">
+            <span class="tooltiptext" id="tooltip">Copy to clipboard</span>
+            email us.
+          </button>
+        </span>
       </p>
     </main>
   </div>
@@ -65,7 +69,9 @@
       </ul>
     </div>
     <div class="time-travel">
-      <p><a href="./time-travel/" title="See past versions of this site">Time Travel</a></p>
+      <p>
+        <a href="./time-travel/" title="See past versions of this site">Time Travel</a>
+      </p>
     </div>
     <p>
       <span class="footer-piece">
@@ -117,6 +123,21 @@
 
     addEventListener('load', markDocumentAsLoaded);
 
+  </script>
+  <script>
+    function copyEmail() {
+      var copyText = document.getElementById("emailInput");
+      copyText.select();
+      document.execCommand("copy");
+
+      var tooltip = document.getElementById("tooltip");
+      tooltip.innerHTML = "Copied: " + copyText.value;
+    }
+
+    function outFunc() {
+      var tooltip = document.getElementById("tooltip");
+      tooltip.innerHTML = "Copy to clipboard";
+    }
   </script>
 </body>
 


### PR DESCRIPTION
### Context
One of the bad UX pattern that needs to immediately die is `mailto` links that open local email clients (*sigh* ).
Opening local email apps have huge cost and weight, as a result I feel either the click actions should have confirmation or ease the interaction with lighter tasks. 
You can read more about this pattern described in the following articles
- https://medium.com/@vitariusbence/we-need-to-talk-about-mailto-links-e32c6afa5639 
- https://blog.prototypr.io/why-a-href-mailto-should-die-aaec2912213f

### Proposal
As a result I am proposing to add ability to copy the email address instead of force open an application.

