### PR TITLE
remove time travel from paragraph

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,9 +64,6 @@
         </li>
       </ul>
     </div>
-    <div class="time-travel">
-      <p><a href="./time-travel/" title="See past versions of this site">Time Travel</a></p>
-    </div>
     <p>
       <span class="footer-piece">
         Designed in


### PR DESCRIPTION
It gives 404, time travel should not be in paragraph, should be only in landing page