### PR TITLE
Improved UX of the theme switcher

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
   <link rel="shortcut icon" href="https://c.s-microsoft.com/favicon.ico?v2" type="image/x-icon">
 </head>
 
-<body>
+<body class="js-theme-dark">
   <div class="container">
     <header>
       <a class="logo-link" href="https://microsoft.com" title="Microsoft Website">
@@ -57,10 +57,10 @@
     <div class="theme">
       <ul class="theme__list">
         <li class="theme__item">
-          <button class="theme__button js-theme-button" value="dark" title="Enable dark theme">Dark</button>
+          <button class="theme__button" value="dark" title="Enable dark theme">Dark</button>
         </li>
         <li class="theme__item">
-          <button class="theme__button js-theme-button" value="light" title="Enable light theme">Light</button>
+          <button class="theme__button" value="light" title="Enable light theme">Light</button>
         </li>
       </ul>
     </div>

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -11,12 +11,16 @@
 /* UI Styling */
 
 .theme {
+  cursor: pointer;
+  display: inline-block;
   position: relative;
-  margin: 1rem 0;
+  margin: auto auto;
+  padding: 0.5rem 0.5rem;
   font-size: 0;
   text-align: center;
   z-index: 1;
   transition: opacity 0.3s ease;
+  pointer-events: all;
 }
 
 .theme__list,
@@ -51,8 +55,16 @@
   width: 1.2rem;
   height: 1.2rem;
   background: blue;
-  border: 1px solid #444;
+  border: 0px solid #444;
   border-radius: 0.6rem;
+  cursor: pointer;
+  z-index: 100;
+}
+
+button.theme__button:focus {
+  text-decoration: none;
+  outline: none;
+  box-shadow: none;
 }
 
 .theme__button[value="dark"] {
@@ -61,16 +73,6 @@
 
 .theme__button[value="light"] {
   background: white;
-}
-
-.theme__button:disabled {
-  z-index: 95;
-  border: 3px solid #444;
-}
-
-.theme__button:not([disabled]) {
-  cursor: pointer;
-  z-index: 100;
 }
 
 @media only screen and (min-width: 640px) {
@@ -116,10 +118,11 @@ body.js-theme-code {
   font-family: "Courier New", Courier, monospace;
 }
 
-.js-theme-light .theme__button {
-  border: 1px solid #dedede;
+.js-theme-dark .theme__button[value="dark"] {
+  z-index: 95;
+  border: 3px solid #828282;
 }
-
-.js-theme-light .theme__button:disabled {
+.js-theme-light .theme__button[value="light"] {
+  z-index: 95;
   border: 3px solid #dedede;
 }

--- a/docs/theme/theme.js
+++ b/docs/theme/theme.js
@@ -1,20 +1,8 @@
 var $body = document.body;
-var $themeBtns = document.querySelectorAll(".js-theme-button");
+var activeTheme = "dark";
 
-$themeBtns[0].setAttribute("disabled", "disabled");
-
-$themeBtns.forEach(function(ele) {
-  ele.onclick = function(e) {
-    var selectedName = e.target.value;
-
-    $themeBtns.forEach(function(ele) {
-      var themeName = ele.value;
-      if (themeName === selectedName) return;
-      $body.classList.remove("js-theme-" + themeName);
-      ele.removeAttribute("disabled");
-    });
-
-    $body.classList.add("js-theme-" + selectedName);
-    ele.setAttribute("disabled", "disabled");
-  };
-});
+document.querySelector(".theme").onclick = function(e) {
+  $body.classList.remove("js-theme-" + activeTheme);
+  activeTheme = activeTheme === "dark" ? "light" : "dark";
+  $body.classList.add("js-theme-" + activeTheme);
+};


### PR DESCRIPTION
So I was looking at the page on my mobile and wasn't able to switch the theme initially. First I thought there were some event handlers missing, but it turned out that hit area of the switcher was limited to one small circle-button, which required very precise aiming. 
Then I looked at it on my desktop and got a similar bad experience. Here the circle-button, to switch the theme, actually moves away from the cursor when trying to hit it. So you end up in a second click, hunting for the "right" circle. With "right" I mean the circle which will indeed change the theme the other state. The other circle is deactivated, which leaves you with an additional task to understand the logic behind it.

Since all you want to do is to change the theme from dark to light or vice versa, the answer to this broader UX/UI problem is, that we are actually having a toggle/switch element here.
The switch should have:
- a large hit area
- the click event switches between the dual state
  - no matter where you hit it

So I changed the UX behaviour of this custom element to behave like a switch. Which solves the problems on mobile & desktop and improves the common user experience.