### PR TITLE
Adjusting variables, removing unused vars

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -11,15 +11,12 @@
   /* typeface defaults */
   --primary-typeface: Segoe UI, SegoeUI, Segoe WP, Helvetica Neue, Helvetica,
     Tahoma, Arial, sans-serif;
-  --title-font-size: 24px;
-  --title-line-height: 30px;
+  --title-font-size: 1.3rem;
   --base-font-size: 20px;
   --base-font-line-height: 28px;
   --small-font-size: 12px;
   --small-font-line-height: 14px;
   /* animations */
-  --page-background: #121212;
-  --page-color: #bbb;
   --root-gradient-animation: 4s both root-gradient linear infinite;
   --move-in-offset: 20px;
   --move-in-animation: 1s both move-in;
@@ -263,7 +260,7 @@ main p:nth-child(4) {
 main h1 {
   animation: var(--move-in-animation);
   animation-delay: calc(var(--move-in-base-delay) * 4);
-  font-size: 1.3rem;
+  font-size: var(--title-font-size);
   font-weight: bold;
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
   margin-bottom: var(--small-space);


### PR DESCRIPTION
There is a bunch of unused variables I have removed. That being said there are some useful ones related to spacing that I believe should be kept for future use.

If the `--page-background: #121212;` variable should be kept it can be a reference to the `--dark-grey` variable instead of doubling up the same colour.

I also adjusted the `--title-font-size` based of the existing styles in `main h1` that were not using variables.