### PR TITLE
Simple One Button Toggle Theme Solution

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
     <div class="theme">
       <ul class="theme__list">
         <li class="theme__item">
-          <button id="switchTheme" class="theme__button dark" value="dark" title="Enable dark theme">Dark</button>
+          <button id="switchTheme" class="theme__button dark" value="dark" title="Switch theme">Dark</button>
         </li>
       </ul>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
     <div class="theme">
       <ul class="theme__list">
         <li class="theme__item">
-          <button id="switchTheme" class="theme__button dark" value="dark" title="Switch theme">Dark</button>
+          <button id="toggleTheme" class="theme__button dark" value="dark" title="Toggle theme">Toggle Theme</button>
         </li>
       </ul>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,10 +56,7 @@
     <div class="theme">
       <ul class="theme__list">
         <li class="theme__item">
-          <button class="theme__button" value="dark" title="Enable dark theme">Dark</button>
-        </li>
-        <li class="theme__item">
-          <button class="theme__button" value="light" title="Enable light theme">Light</button>
+          <button id="switchTheme" class="theme__button dark" value="dark" title="Enable dark theme">Dark</button>
         </li>
       </ul>
     </div>

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -68,10 +68,12 @@ button.theme__button:focus {
 
 .light {
   background: black;
+  border: 3px solid #828282;
 }
 
 .dark {
   background: white;
+  border: 3px solid #dedede;
 }
 
 @media only screen and (min-width: 640px) {
@@ -123,11 +125,9 @@ body.js-theme-code {
   font-family: "Courier New", Courier, monospace;
 }
 
-.js-theme-dark .theme__button[value="dark"] {
+.js-theme-dark .theme__button {
   z-index: 95;
-  border: 3px solid #828282;
 }
-.js-theme-light .theme__button[value="light"] {
+.js-theme-light .theme__button {
   z-index: 95;
-  border: 3px solid #dedede;
 }

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -66,11 +66,11 @@ button.theme__button:focus {
   box-shadow: none;
 }
 
-.theme__button[value="dark"] {
+.light {
   background: black;
 }
 
-.theme__button[value="light"] {
+.dark {
   background: white;
 }
 

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -30,6 +30,11 @@
   box-sizing: border-box;
 }
 
+.theme__button:hover {
+  width: 5.5rem;
+  text-indent: 0px;
+}
+
 .theme__list {
   list-style: none;
   animation: 1s both fade-in;
@@ -51,8 +56,8 @@
   display: block;
   position: relative;
   text-indent: -9999px;
-  width: 1.2rem;
-  height: 1.2rem;
+  width: 1.4rem;
+  height: 1.4rem;
   background: blue;
   border: 0px solid #444;
   border-radius: 0.6rem;
@@ -69,11 +74,13 @@ button.theme__button:focus {
 .light {
   background: black;
   border: 3px solid #828282;
+  color: white;
 }
 
 .dark {
   background: white;
   border: 3px solid #dedede;
+  color: black;
 }
 
 @media only screen and (min-width: 640px) {

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -56,14 +56,14 @@
   display: block;
   position: relative;
   text-indent: -9999px;
-  width: 1.4rem;
-  height: 1.4rem;
+  width: 1.2rem;
+  height: 1.2rem;
   background: blue;
   border: 0px solid #444;
   border-radius: 0.6rem;
   cursor: pointer;
   z-index: 100;
-  line-height: 0.7rem;
+  line-height: 0.6rem;
 }
 
 button.theme__button:focus {
@@ -85,9 +85,6 @@ button.theme__button:focus {
 }
 
 @media only screen and (min-width: 640px) {
-  .theme {
-    opacity: 0.5;
-  }
   .theme:hover {
     opacity: 1;
   }

--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -63,6 +63,7 @@
   border-radius: 0.6rem;
   cursor: pointer;
   z-index: 100;
+  line-height: 0.7rem;
 }
 
 button.theme__button:focus {

--- a/docs/theme/theme.js
+++ b/docs/theme/theme.js
@@ -1,5 +1,5 @@
 var $body = document.body;
-var switchButton = document.getElementById("switchTheme");
+var switchButton = document.getElementById("toggleTheme");
 var activeTheme = "dark";
 
 document.querySelector(".theme").onclick = function(e) {

--- a/docs/theme/theme.js
+++ b/docs/theme/theme.js
@@ -1,8 +1,11 @@
 var $body = document.body;
+var switchButton = document.getElementById("switchTheme");
 var activeTheme = "dark";
 
 document.querySelector(".theme").onclick = function(e) {
   $body.classList.remove("js-theme-" + activeTheme);
+  switchButton.classList.remove(activeTheme);
   activeTheme = activeTheme === "dark" ? "light" : "dark";
   $body.classList.add("js-theme-" + activeTheme);
+  switchButton.classList.add(activeTheme);
 };


### PR DESCRIPTION
The current solution to the theme toggling is nice, but I believe the user experience is flawed.

Right now, we have two buttons for a binary toggle. We don't need these two buttons. The user also needs to hover over the two conjoined buttons to toggle the theme. In my opinion, this is too complex for simple theming functionality. Right now, I can even click anywhere in the theme div to change the theme. 

The solution is to simplify the model.

Instead of the current toggling method, we could have one button that changes color when clicked. On hover, "Toggle Theme" text is shown for clarity.

This way, the user does not need to hover over the two buttons and click one button depending on which one is disabled. 

While this solution is less flashy, it is also more functional.

<img width="240" alt="screen shot 2018-07-27 at 4 32 43 am" src="https://user-images.githubusercontent.com/39655284/43310666-3ac4fd2c-9156-11e8-8365-31a7cbb26ca9.png">
<img width="240" alt="screen shot 2018-07-27 at 4 32 35 am" src="https://user-images.githubusercontent.com/39655284/43310667-3ad32a28-9156-11e8-9882-3774d1578ab9.png">
<img width="307" alt="screen shot 2018-07-27 at 9 26 28 am 1" src="https://user-images.githubusercontent.com/39655284/43323282-31fb9dbc-917f-11e8-9fc3-82911e11c680.png">
