### PR TITLE
Disable time travel button in time travel mode

### DIFF
--- a/docs/time-travel/index.html
+++ b/docs/time-travel/index.html
@@ -22,7 +22,7 @@
     <main class="display-wrapper">
       <iframe id="js-display" class="display" src="" frameborder="0"></iframe>
     </main>
-    <div class="history">
+    <div id="js-history" class="history">
       <h2 class="history__count">
         <span id="js-history-id">1</span>
         <span class="-text--fade">/</span>

--- a/docs/time-travel/style.css
+++ b/docs/time-travel/style.css
@@ -16,7 +16,8 @@ html {
 
 body {
   font-size: 16px;
-  font-family: Segoe UI, SegoeUI, Segoe WP, Helvetica Neue, Helvetica, Tahoma, Arial, sans-serif;
+  font-family: Segoe UI, SegoeUI, Segoe WP, Helvetica Neue, Helvetica, Tahoma,
+    Arial, sans-serif;
   line-height: 1.25;
   color: #bbb;
 }
@@ -38,6 +39,35 @@ hr {
 
 /* components */
 
+.toast {
+  position: absolute;
+  bottom: 1rem;
+  right: 2rem;
+  font-size: 1rem;
+  padding: 0.75em 1em;
+  max-width: calc(100% - 4rem);
+  border-radius: 0.25rem;
+  color: #bbb;
+  background: #2e2e2e;
+  opacity: 0;
+  transform: translateY(4rem);
+  transition: all 0.3s ease;
+}
+
+.toast.js-inactive {
+  display: none;
+}
+
+.toast--warning {
+  background: #2e2e2e;
+  color: #ffba08;
+}
+
+.toast.js-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .container {
   position: relative;
   display: flex;
@@ -55,11 +85,13 @@ hr {
 }
 
 .history {
+  position: relative;
   flex: 1 1 10rem;
   padding: 2rem;
   background: rgba(18, 18, 18, 1);
   color: #bbb;
   border-left: 1px solid rgba(255, 255, 255, 0.12);
+  overflow: hidden;
 }
 
 .history > a {


### PR DESCRIPTION
(WIP) The relative time travel link is broken in time travel mode (my bad) & should be disabled. I'm trying out these 2 message positions:

#### Toast on click
![time-travel-toast](https://user-images.githubusercontent.com/3383539/43337410-ca4f0f10-920e-11e8-9744-885e21677277.gif)

#### Tooltip on hover
![time-travel-tooltip](https://user-images.githubusercontent.com/3383539/43337438-e29c9952-920e-11e8-8739-63498687d504.gif)

Which one is better, position wise? Suggestion on other ideas are welcome too.