### PR TITLE
Fix incorrect link color in light theme

### DIFF
--- a/docs/theme/theme.css
+++ b/docs/theme/theme.css
@@ -105,7 +105,7 @@ body.js-theme-light {
 }
 
 .js-theme-light a {
-  color: var(--blue);
+  color: var(--brand-blue);
 }
 
 .js-theme-light a:hover {


### PR DESCRIPTION
Currently in the light theme the links are pointing to an incorrect css variable causing them to be indistinguishable from the surrounding text. This PR fixes this.
 
Before:
![2018-08-02-221355_899x703_selection](https://user-images.githubusercontent.com/2308484/43620587-77b14272-96a1-11e8-8fd6-1f54ab872593.png)

After:
![2018-08-02-221404_770x697_selection](https://user-images.githubusercontent.com/2308484/43620593-8145ae40-96a1-11e8-9c6f-07a254add547.png)
