### PR TITLE
changed max-width of container class

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -205,7 +205,7 @@ h1 {
 /* Container */
 
 .container {
-  max-width: 31rem;
+  max-width: 34rem;
   margin: 0 auto auto;
 }
 


### PR DESCRIPTION
I increased the max-width of 'container' to 34 rem. This allowed the link 'microsoft/join-dev-design' to be on the same line. In doing so, the link appears more organized while keeping the overall look (which I really enjoy). Another reason for this change was to fix a bug with the link when viewed in Safari. The word 'design' disappears when hovering over the link (pictures attached). Putting it all on the same line eliminates that problem. 
<img width="1404" alt="screenshot_1" src="https://user-images.githubusercontent.com/36672462/44570171-bd8a6580-a731-11e8-848a-d0e9d1745327.png">
<img width="1405" alt="screenshot_2" src="https://user-images.githubusercontent.com/36672462/44570172-be22fc00-a731-11e8-81a3-27bfefc914ee.png">