### PR TITLE
Make PR merge date more readable

### DIFF
--- a/docs/time-travel/time-travel.js
+++ b/docs/time-travel/time-travel.js
@@ -198,7 +198,8 @@ const timeTravel = async () => {
       $prAuthorAvatar.setAttribute("alt", `No editor`);
     }
 
-    $prMergedAt.textContent = `Merged at ${mergedAt}`;
+    const d = new Date(mergedAt);
+    $prMergedAt.textContent = `Merged on ${d.toLocaleDateString()} at ${d.toLocaleTimeString()}`;
     $prUrl.href = url;
   };
 


### PR DESCRIPTION
The datestamp currently is not very readable:

![image](https://user-images.githubusercontent.com/6725396/47420965-2f267480-d7b2-11e8-8e0c-c4525029842d.png)

Updated it to:

![image](https://user-images.githubusercontent.com/6725396/47420991-39e10980-d7b2-11e8-96f5-a569ec6a61df.png)