### PR TITLE
#172 centered container for large screens

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -218,6 +218,12 @@ h1 {
   }
 }
 
+@media only screen and (min-height: 860px) {
+  .container {
+    margin: auto;
+  }
+}
+
 main p:nth-child(2) {
   animation-delay: calc(var(--move-in-base-delay) * 6);
 }


### PR DESCRIPTION
On large screens, specifically very large screens like 4K monitors, the `container` element was stuck to the top of the browser. Added `margin` styles keep it centered when the browser becomes too tall. Future improvement would be to change positioning to allow for animation of this transition, but `auto` is not an animatable value.