### PR TITLE
Improve time machine layout

### DIFF
--- a/docs/time-travel/style.css
+++ b/docs/time-travel/style.css
@@ -80,13 +80,14 @@ hr {
 }
 
 .display {
+  display: block;
   width: 100%;
-  height: 100%;
+  height: 100vh;
 }
 
 .history {
   position: relative;
-  flex: 1 1 10rem;
+  width: 20em;
   padding: 2rem;
   background: rgba(18, 18, 18, 1);
   color: #bbb;
@@ -218,20 +219,28 @@ hr {
   .container {
     flex-flow: column nowrap;
   }
+
   .display-wrapper {
     height: calc(100%-5.5rem);
     overflow-y: scroll;
   }
+
   .history__count {
     font-size: 1rem;
   }
+
   .pr__title {
     font-size: 1.25rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
   .people--editor {
     display: none;
+  }
+
+  .history {
+    width: 100%;
   }
 }


### PR DESCRIPTION
This fixes a few issues with the time machine layout.

For one, it sets the iframe to `display: block` to avoid the small space below it causing the scroll bar to show up.

Fixes this:

![image](https://user-images.githubusercontent.com/17094139/47601253-b6c2dd80-d982-11e8-8d88-488eb900b9df.png)

Then, it also fixes some issues with the sidebar on smaller screen sizes. It does this by setting a fixed with on it instead of using flex properties.

Fixes these things:

![image](https://user-images.githubusercontent.com/17094139/47601273-05707780-d983-11e8-88d9-820277261017.png)
![image](https://user-images.githubusercontent.com/17094139/47601299-449ec880-d983-11e8-96e1-c124086624cc.png)

(Sorry for the messy handwriting on images)
